### PR TITLE
fix: assessments and answers api url names

### DIFF
--- a/dream-big-api/app/api/answers_api.rb
+++ b/dream-big-api/app/api/answers_api.rb
@@ -25,7 +25,7 @@ class AnswersApi < Grape::API
     requires :assessment_id, type: Integer, desc: 'assessment ID'
     requires :question_text, type: String, desc: 'question text'
   end
-  post '/Answers' do
+  post '/answers' do
     answers_parameters = ActionController::Parameters.new(params)
       .permit(
         :id,
@@ -50,7 +50,7 @@ class AnswersApi < Grape::API
     optional :question_text, type: String, desc: 'question text'
 
   end
-  put '/Answers/:id' do
+  put '/answers/:id' do
     answers_parameters = ActionController::Parameters.new(params)
       .permit(
         :id,
@@ -71,12 +71,12 @@ class AnswersApi < Grape::API
   params do
     requires :id, type: Integer, desc: 'ID of Answer'
   end
-  delete '/Answers/:id' do
+  delete '/answers/:id' do
     Answers.find(params[:id]).destroy!
     true
   end
 
-  get '/Answers' do
+  get '/answers' do
     result = Answers.all
 
     present result, with: Entities::AnswersEntity

--- a/dream-big-api/app/api/assessments_api.rb
+++ b/dream-big-api/app/api/assessments_api.rb
@@ -25,7 +25,7 @@ class AssessmentsApi < Grape::API
     requires :category_id, type: Integer, desc: 'category ID'
     requires :timestamps, type: Integer, desc: 'Timestamp of assessment'
   end
-  post '/Assessments' do
+  post '/assessments' do
     assessments_parameters = ActionController::Parameters.new(params)
       .permit(
         :id,
@@ -50,7 +50,7 @@ class AssessmentsApi < Grape::API
     optional :timestamps, type: Integer, desc: 'Timestamp of assessment'
 
   end
-  put '/Assessments/:id' do
+  put '/assessments/:id' do
     assessments_parameters = ActionController::Parameters.new(params)
       .permit(
         :id,
@@ -71,12 +71,12 @@ class AssessmentsApi < Grape::API
   params do
     requires :id , type: Integer, desc: 'Assessment ID'
   end
-  delete '/Assessments/:id' do
+  delete '/assessments/:id' do
     Assessments.find(params[:id]).destroy!
     true
   end
 
-  get '/Assessments' do
+  get '/assessments' do
     result = Assessments.all
 
     present result, with: Entities::AssessmentsEntity


### PR DESCRIPTION
Fixed names to be all lowercase to match current convention.