### PR TITLE
feat: add category questions api

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/dream-big.iml
+++ b/.idea/dream-big.iml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="RUBY_MODULE" version="4">
+  <component name="ModuleRunConfigurationManager">
+    <shared />
+  </component>
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/features" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="PROVIDED" name="actioncable (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionmailbox (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionmailer (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionpack (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actiontext (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionview (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="active_model_serializers (v0.10.13, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activejob (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activemodel (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activerecord (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activestorage (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activesupport (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="addressable (v2.8.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ast (v2.4.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bcrypt (v3.1.18, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="better_errors (v2.9.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bootsnap (v1.12.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="builder (v3.2.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bundler (v2.3.25, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="byebug (v11.1.3, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="case_transform (v0.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="code_analyzer (v0.5.5, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="coderay (v1.1.3, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.1.10, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="crack (v0.4.5, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="crass (v1.0.6, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="database_cleaner (v2.0.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="database_cleaner-active_record (v2.0.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="database_cleaner-core (v2.0.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="devise (v4.8.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="digest (v3.1.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="docile (v1.4.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="dry-container (v0.10.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="dry-core (v0.7.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="dry-inflector (v0.3.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="dry-logic (v1.2.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="dry-types (v1.5.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="erubi (v1.11.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="erubis (v2.7.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="factory_bot (v6.2.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="factory_bot_rails (v6.2.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="faker (v2.21.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ffi (v1.15.5, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="globalid (v1.0.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="grape (v1.6.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="grape-entity (v0.10.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="grape-swagger (v1.4.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="grape-swagger-rails (v0.3.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="hashdiff (v1.0.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="i18n (v1.12.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="json (v2.6.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="jsonapi-renderer (v0.2.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="jwt (v2.4.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="listen (v3.7.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="loofah (v2.19.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="mail (v2.7.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="marcel (v1.0.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="method_source (v1.0.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="mini_mime (v1.1.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="minitest (v5.16.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="minitest-around (v0.5.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="msgpack (v1.5.3, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="multi_json (v1.15.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="mustermann (v1.1.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="mustermann-grape (v1.0.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="mysql2 (v0.5.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="net-imap (v0.2.3, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="net-pop (v0.1.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="net-protocol (v0.1.3, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="net-smtp (v0.3.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="nio4r (v2.5.8, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="nokogiri (v1.13.9, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="orm_adapter (v0.5.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="parallel (v1.22.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="parser (v3.1.2.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="public_suffix (v4.0.7, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="puma (v5.6.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="racc (v1.6.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rack (v2.2.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rack-accept (v0.4.5, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rack-cors (v1.1.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rack-test (v2.0.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rails (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rails-dom-testing (v2.0.3, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rails-html-sanitizer (v1.4.3, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rails_best_practices (v1.23.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="railties (v7.0.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rainbow (v3.1.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rake (v13.0.6, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rb-fsevent (v0.11.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rb-inotify (v0.10.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.5.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="require_all (v3.0.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="responders (v3.0.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rexml (v3.2.5, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop (v1.31.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-ast (v1.19.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-faker (v1.1.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-rails (v2.15.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ruby-progressbar (v1.11.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="sexp_processor (v4.16.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov (v0.21.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov-html (v0.12.3, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov_json_formatter (v0.1.4, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="spring (v4.0.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="sprockets (v4.1.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="sprockets-rails (v3.4.2, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="strscan (v3.0.3, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="thor (v1.2.1, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="timeout (v0.3.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="tzinfo (v2.0.5, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="unicode-display_width (v2.2.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="warden (v1.2.9, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="webmock (v3.14.0, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="websocket-driver (v0.7.5, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="websocket-extensions (v0.1.5, RVM: ruby-3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="zeitwerk (v2.6.5, RVM: ruby-3.1.2) [gem]" level="application" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="RVM: ruby-3.1.2" project-jdk-type="RUBY_SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/dream-big.iml" filepath="$PROJECT_DIR$/.idea/dream-big.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/dream-big-api/app/api/category_api.rb
+++ b/dream-big-api/app/api/category_api.rb
@@ -19,14 +19,12 @@ class CategoryApi < Grape::API
   
     requires :name, type: String, desc: 'Category name'
     requires :description, type: String, desc: 'The description of the category'
-    requires :weight_values_id, type: Integer, desc: 'default weight for category'
   end
   post '/category' do
     category_parameters = ActionController::Parameters.new(params)
       .permit(
         :name,
         :description,
-        :weight_values_id
       )
 
     # Auth...
@@ -41,14 +39,12 @@ class CategoryApi < Grape::API
     
     optional :name, type: String, desc: 'The categoryr name'
     optional :description, type: String, desc: 'The description of the category'
-    optional :weight_values_id, type: Integer, desc: 'default weight for category'
   end
   put '/category/:id' do
     category_parameters = ActionController::Parameters.new(params)
       .permit(
         :name,
         :description,
-        :weight_value_id
         #Ex:- :default =>''
       )
 

--- a/dream-big-api/app/api/category_questions_api.rb
+++ b/dream-big-api/app/api/category_questions_api.rb
@@ -1,0 +1,70 @@
+require 'grape'
+
+class CategoryQuestionsApi < Grape::API
+  desc 'Allow retrieval of an Answer in the Assessment'
+  get '/category-questions/:id' do
+    # Auth
+
+    result = CategoryQuestion.find(params[:id])
+    present result, with: Entities::CategoryQuestionsEntity
+  end
+
+  desc 'Allow creation of a Category Question'
+  params do
+    requires :id, type: Integer, desc: 'ID of the Category Question'
+    requires :question, type: String, desc: 'question text'
+    requires :category_id, type: Integer, desc: 'category ID'
+  end
+  post '/category-questions' do
+    category_questions_parameters = ActionController::Parameters
+        .new(params)
+        .permit(
+          :id,
+          :question,
+          :category_id
+        )
+
+    # Auth...
+
+    result = CategoryQuestion.create!(category_questions_parameters)
+
+    present result, with: Entities::CategoryQuestionsEntity
+  end
+
+  desc 'Allow updating a Category Question'
+  params do
+    requires :id, type: Integer, desc: 'ID of the Category Question'
+    optional :question, type: String, desc: 'question text'
+    optional :category_id, type: Integer, desc: 'category ID'
+  end
+  put '/category-questions/:id' do
+    category_questions_parameters = ActionController::Parameters
+        .new(params)
+        .permit(
+          :question,
+          :category_id,
+        )
+
+    # Auth
+
+    result = CategoryQuestion.find(params[:id])
+    result.update!(category_questions_parameters)
+
+    present result, with: Entities::CategoryQuestionsEntity
+  end
+
+  desc 'Delete the Category Question with the indicated id'
+  params do
+    requires :id, type: Integer, desc: 'ID of the Category Question'
+  end
+  delete '/category-questions/:id' do
+    CategoryQuestion.find(params[:id]).destroy!
+    true
+  end
+
+  get '/category-questions' do
+    result = CategoryQuestion.all
+
+    present result, with: Entities::CategoryQuestionsEntity
+  end
+end

--- a/dream-big-api/app/api/dream_big_api.rb
+++ b/dream-big-api/app/api/dream_big_api.rb
@@ -55,7 +55,8 @@ class DreamBigApi < Grape::API
   mount AvatarTorsosApi
   mount AnswersApi
   mount AssessmentsApi
-  
+  mount CategoryQuestionsApi
+
   add_swagger_documentation(
     base_path: nil,
     api_version: "v1",

--- a/dream-big-api/app/api/entities/category_questions_entity.rb
+++ b/dream-big-api/app/api/entities/category_questions_entity.rb
@@ -3,6 +3,5 @@ module Entities
       expose :id
       expose :question
       expose :category_id
-      expose :timestamps
     end
   end

--- a/dream-big-api/app/models/category_question.rb
+++ b/dream-big-api/app/models/category_question.rb
@@ -1,2 +1,4 @@
 class CategoryQuestion < ApplicationRecord
+  #associations
+  has_one :categories
 end

--- a/dream-big-api/db/migrate/20221107232332_create_category_questions.rb
+++ b/dream-big-api/db/migrate/20221107232332_create_category_questions.rb
@@ -3,7 +3,6 @@ class CreateCategoryQuestions < ActiveRecord::Migration[7.0]
     create_table :category_questions do |t|
       t.string :question
       t.bigint :category_id
-      t.bigint :assessment_id
       t.timestamps
     end
   end

--- a/dream-big-api/db/migrate/20221113035136_update_all_fk.rb
+++ b/dream-big-api/db/migrate/20221113035136_update_all_fk.rb
@@ -1,7 +1,6 @@
 class UpdateAllFk < ActiveRecord::Migration[7.0]
   def change
-    add_foreign_key :answers, :assessments, ondelete: :cascade, column: :assessment_id
-    add_foreign_key :category_questions, :assessments, ondelete: :cascade, column: :assessment_id
+    add_foreign_key :category_questions, :categories, ondelete: :cascade, column: :category_id
     add_foreign_key :planets, :journeys, ondelete: :cascade, column: :journey_id
     add_foreign_key :sections, :planets, ondelete: :cascade, column: :planet_id
     add_foreign_key :plans, :sections, ondelete: :cascade, column: :section_id

--- a/dream-big-api/db/schema.rb
+++ b/dream-big-api/db/schema.rb
@@ -11,16 +11,15 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2022_11_13_035136) do
-  create_table "answers", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "answers", charset: "utf8mb4", force: :cascade do |t|
     t.string "answer"
     t.bigint "question_id"
     t.bigint "assessment_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["assessment_id"], name: "fk_rails_6b44a1e939"
   end
 
-  create_table "assessments", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "assessments", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "journey_id"
     t.bigint "category_id"
     t.datetime "created_at", null: false
@@ -29,23 +28,23 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_035136) do
     t.index ["journey_id"], name: "fk_rails_523a28d8ff"
   end
 
-  create_table "avatar_accessories", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "avatar_accessories", charset: "utf8mb4", force: :cascade do |t|
     t.string "imgpath"
   end
 
-  create_table "avatar_hairs", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "avatar_hairs", charset: "utf8mb4", force: :cascade do |t|
     t.string "imgpath"
   end
 
-  create_table "avatar_heads", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "avatar_heads", charset: "utf8mb4", force: :cascade do |t|
     t.string "imgpath"
   end
 
-  create_table "avatar_torsos", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "avatar_torsos", charset: "utf8mb4", force: :cascade do |t|
     t.string "imgpath"
   end
 
-  create_table "avatars", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "avatars", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "avatar_head_id"
     t.bigint "avatar_torsos_id"
     t.bigint "avatar_hairs_id"
@@ -56,21 +55,20 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_035136) do
     t.index ["avatar_torsos_id"], name: "fk_rails_12f7f2f036"
   end
 
-  create_table "categories", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "categories", charset: "utf8mb4", force: :cascade do |t|
     t.string "name"
     t.string "description"
   end
 
-  create_table "category_questions", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "category_questions", charset: "utf8mb4", force: :cascade do |t|
     t.string "question"
     t.bigint "category_id"
-    t.bigint "assessment_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["assessment_id"], name: "fk_rails_2912916704"
+    t.index ["category_id"], name: "fk_rails_c8560d80b7"
   end
 
-  create_table "goals", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "goals", charset: "utf8mb4", force: :cascade do |t|
     t.string "goal_text"
     t.boolean "status"
     t.bigint "section_id"
@@ -79,7 +77,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_035136) do
     t.index ["section_id"], name: "fk_rails_d221e21327"
   end
 
-  create_table "journeys", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "journeys", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "student_id"
     t.bigint "assessment_id"
     t.datetime "created_at", null: false
@@ -87,7 +85,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_035136) do
     t.index ["student_id"], name: "fk_rails_339ec94246"
   end
 
-  create_table "planets", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "planets", charset: "utf8mb4", force: :cascade do |t|
     t.string "name"
     t.bigint "journey_id"
     t.datetime "created_at", null: false
@@ -95,7 +93,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_035136) do
     t.index ["journey_id"], name: "fk_rails_c2aa27ce2d"
   end
 
-  create_table "plans", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "plans", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "section_id"
     t.bigint "goal_id"
     t.string "plan_text"
@@ -104,7 +102,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_035136) do
     t.index ["section_id"], name: "fk_rails_654aad63df"
   end
 
-  create_table "reflections", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "reflections", charset: "utf8mb4", force: :cascade do |t|
     t.string "reflection_text"
     t.bigint "section_id"
     t.bigint "goal_id"
@@ -114,11 +112,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_035136) do
     t.index ["section_id"], name: "fk_rails_a0dafb49d1"
   end
 
-  create_table "roles", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "roles", charset: "utf8mb4", force: :cascade do |t|
     t.string "role_description"
   end
 
-  create_table "sections", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "sections", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "planet_id"
     t.bigint "category_id"
     t.datetime "created_at", null: false
@@ -126,7 +124,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_035136) do
     t.index ["planet_id"], name: "fk_rails_b68e7824b8"
   end
 
-  create_table "students", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "students", charset: "utf8mb4", force: :cascade do |t|
     t.string "firstName"
     t.string "lastName"
     t.integer "phone"
@@ -138,12 +136,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_035136) do
     t.index ["user_id"], name: "fk_rails_148c9e88f4"
   end
 
-  create_table "teachers", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "teachers", charset: "utf8mb4", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "users", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "users", charset: "utf8mb4", force: :cascade do |t|
     t.string "name"
     t.string "username"
     t.string "email"
@@ -154,14 +152,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_035136) do
     t.index ["role_id"], name: "fk_rails_642f17018b"
   end
 
-  add_foreign_key "answers", "assessments"
   add_foreign_key "assessments", "categories"
   add_foreign_key "assessments", "journeys"
   add_foreign_key "avatars", "avatar_accessories", column: "avatar_accessories_id"
   add_foreign_key "avatars", "avatar_hairs", column: "avatar_hairs_id"
   add_foreign_key "avatars", "avatar_heads"
   add_foreign_key "avatars", "avatar_torsos", column: "avatar_torsos_id"
-  add_foreign_key "category_questions", "assessments"
+  add_foreign_key "category_questions", "categories"
   add_foreign_key "goals", "sections"
   add_foreign_key "journeys", "students"
   add_foreign_key "planets", "journeys"


### PR DESCRIPTION
To allow category questions to be added as per the UML diagram. Completed the following.
- removed weight values id from assessments to allow the creation of an assessment
- added support to RubyMine (hence the .idea generated files) to allow intellisense since VSCode does not support this.
- added the category questions api
- removed the reference of fk assessment in the category questions schema since the UML diagram didn't include it.