### PR TITLE
feat: add /authentication/method api

### DIFF
--- a/dream-big-api/Gemfile
+++ b/dream-big-api/Gemfile
@@ -2,27 +2,10 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.1.2"
-
-# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.3", ">= 7.0.3.1"
-
-# Use mysql as the database for Active Record
 gem "mysql2", "~> 0.5"
-
-# Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"
-
-# Build JSON APIs with ease [https://github.com/rails/jbuilder]
-# gem "jbuilder"
-
-# Use Redis adapter to run Action Cable in production
-# gem "redis", "~> 4.0"
-
-# Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
-# gem "kredis"
-
-# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "dotenv-rails"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]

--- a/dream-big-api/Gemfile.lock
+++ b/dream-big-api/Gemfile.lock
@@ -109,6 +109,10 @@ GEM
       warden (~> 1.2.3)
     digest (3.1.0)
     docile (1.4.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     dry-container (0.10.0)
       concurrent-ruby (~> 1.0)
     dry-core (0.7.1)
@@ -326,6 +330,7 @@ DEPENDENCIES
   database_cleaner
   debug
   devise
+  dotenv-rails
   factory_bot
   factory_bot_rails
   faker

--- a/dream-big-api/app/api/authentication_api.rb
+++ b/dream-big-api/app/api/authentication_api.rb
@@ -1,0 +1,12 @@
+require 'grape'
+
+class AuthenticationApi < Grape::API
+  desc 'Authentication method configuration'
+  get '/authentication/method' do
+    response = {
+      method: DreamBig_Api::Application.config.auth_method
+    }
+
+    present response, with: Grape::Presenters::Presenter
+  end
+end

--- a/dream-big-api/app/api/dream_big_api.rb
+++ b/dream-big-api/app/api/dream_big_api.rb
@@ -45,6 +45,7 @@ class DreamBigApi < Grape::API
   end
 
   #mount DreamBigApi
+  mount AuthenticationApi
   mount CategoryApi
   mount UsersApi
   mount StudentApi

--- a/dream-big-api/app/helpers/authentication_helpers.rb
+++ b/dream-big-api/app/helpers/authentication_helpers.rb
@@ -1,0 +1,24 @@
+module AuthenticationHelpers
+  module_function
+
+  #
+  # Returns true if using SAML2.0 auth strategy
+  #
+  def saml_auth?
+    DreamBig_Api::Application.config.auth_method == :saml
+  end
+
+  #
+  # Returns true if using AAF devise auth strategy
+  #
+  def aaf_auth?
+    DreamBig_Api::Application.config.auth_method == :aaf
+  end
+
+  #
+  # Returns true if using database devise auth strategy
+  #
+  def db_auth?
+    DreamBig_Api::Application.config.auth_method == :database
+  end
+end

--- a/dream-big-api/config/application.rb
+++ b/dream-big-api/config/application.rb
@@ -1,5 +1,5 @@
+require File.expand_path('../boot', __FILE__)
 require_relative "boot"
-
 require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
@@ -10,6 +10,14 @@ module DreamBig_Api
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
+
+    Dotenv::Railtie.load
+
+    # ==> Authentication Method
+    # Authentication method default is database, but possible settings
+    # are: database, aaf, or saml. It can be overridden using the DF_AUTH_METHOD
+    # environment variable.
+    config.auth_method = (ENV['DF_AUTH_METHOD'] || :database).to_sym
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Adding boilerplate to make way for SSO. This commit adds the /authentication/method endpoint to return the environment variable stored authentication method.

Will be migration the /auth/login to this endpoint in the future.