### PR TITLE
feature: add auth_token to user

### DIFF
--- a/dream-big-api/app/api/entities/users_entity.rb
+++ b/dream-big-api/app/api/entities/users_entity.rb
@@ -4,7 +4,6 @@ module Entities
     expose :username
     expose :name
     expose :email
-    expose :password
     expose :role_id
   end
 end

--- a/dream-big-api/app/models/user.rb
+++ b/dream-big-api/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
     require "securerandom"
     has_secure_password
+    # Make the token more secure and harder to guess.
+    has_secure_token :auth_token, length: 24
+    
     validates :email, presence: true, uniqueness: true
     validates :username, presence: true, uniqueness: true
     validates :password, presence: true
@@ -9,4 +12,21 @@ class User < ApplicationRecord
     has_one :student
     has_one :role
 
+    # Make temporary token inaccessible on creation
+    after_create do
+        self.auth_token = nil
+        self.save
+    end
+
+    def self.generate_token(user)
+        user.regenerate_auth_token
+        user.auth_token_expiry = Time.zone.now + 30.second
+        user.save
+    end
+
+    def self.invalidate_token(user)
+        user.auth_token = nil
+        user.auth_token_expiry = nil
+        user.save
+    end
 end

--- a/dream-big-api/db/migrate/20220725225014_create_users.rb
+++ b/dream-big-api/db/migrate/20220725225014_create_users.rb
@@ -6,6 +6,8 @@ class CreateUsers < ActiveRecord::Migration[7.0]
       t.string :email
       t.string :password_digest
       t.bigint :role_id
+      t.string :auth_token
+      t.datetime :auth_token_expiry
       t.timestamps
     end
     add_foreign_key :users, :roles, ondelete: :cascade, column: :role_id

--- a/dream-big-api/db/schema.rb
+++ b/dream-big-api/db/schema.rb
@@ -150,6 +150,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_035136) do
     t.string "email"
     t.string "password_digest"
     t.bigint "role_id"
+    t.string "auth_token"
+    t.datetime "auth_token_expiry" 
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["role_id"], name: "fk_rails_642f17018b"


### PR DESCRIPTION
Added a temporary auth_token mechanism to the user model to allow users to temporarily login via a url parameters when using AAF RapidConnect to log in for SSO. The URL parameter method was needed since we couldn't pass a cookie or header since we are creating a redirect in POST /auth/jwt. Thus, the token is only ever used to login within a 30 second timeframe and then invalidated. Then we take the usual JWT token route for logging in.

Note the user model has also removed password restrictions since these were causing conflictions to the API calls and weren't needed since we are using Rails has_secure_password mechanism. Moreover, we shouldn't be exposing password details in the API client.